### PR TITLE
fix: Don't enable lsp complete for starting buffer

### DIFF
--- a/plugin/lsp.vim
+++ b/plugin/lsp.vim
@@ -30,7 +30,6 @@ def OptionsChanged()
     var opts = vimcompletor.GetOptions('lsp')
     if !opts->empty()
         complete.options->extend(opts)
-        Register()
     endif
 enddef
 


### PR DESCRIPTION
LSP completion is enabled always in the startup buffer due to the `Register()` call during `OptionsChanged()`. Now, with this call removed, LSP completion source is added only via LspAttached autocommand.

Without this fix, when starting vim as `vim abc.txt`, we get error messages like:
```
Error: Language server for "text" file type supporting "completion" feature is not found
```